### PR TITLE
FE <> MCP integration

### DIFF
--- a/backend/gemini/__init__.py
+++ b/backend/gemini/__init__.py
@@ -1,0 +1,3 @@
+from .image_recognition import get_info
+
+__all__ = ["get_info"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ pytesseract>=0.3.10
 Pillow>=10.0.0
 numpy>=1.24.0
 google-genai>=0.3.0
+fastapi>=0.115.0
+pydantic>=2.10.0

--- a/backend/run.py
+++ b/backend/run.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "mcp_server"))
 logger = logging.getLogger(__name__)
 
 
-async def main() -> None:
+async def main():
     server = DelphiOCRServer()
 
     async with stdio_server() as (read_stream, write_stream):
@@ -46,5 +46,6 @@ if __name__ == "__main__":
         logger.warning(
             "No .env file found."
         )
+        raise SystemExit(1)
 
     asyncio.run(main())

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,21 +24,25 @@ Delphi is a React Native application designed to assist blind and visually impai
 ### Installation
 
 1. Install dependencies:
+
 ```bash
 npm install
 ```
 
 2. Install additional dependencies for camera and speech:
+
 ```bash
 npx expo install expo-camera expo-av expo-speech expo-permissions
 ```
 
 3. Start the development server:
+
 ```bash
 npm start
 ```
 
 4. Run on Android:
+
 ```bash
 npm run android
 ```
@@ -77,18 +81,21 @@ frontend/
 ## Key Components
 
 ### HomePage
+
 - Welcome screen with assistant introduction
 - Large, accessible buttons for navigation
 - Voice feedback for all interactions
 - Assistant icon in the center
 
 ### ChatScreen
+
 - Interactive chat interface
 - Text input with voice feedback
 - Simulated AI responses (ready for Gemini API integration)
 - Back navigation
 
 ### ObservationScreen
+
 - Camera integration for environment scanning
 - Real-time scanning with voice feedback
 - Permission handling for camera access

--- a/frontend/services/MCPService.js
+++ b/frontend/services/MCPService.js
@@ -1,0 +1,75 @@
+const BASE_URL = process.env.EXPO_PUBLIC_MCP_URL || "http://localhost:8000";
+const OCR_ROUTE = "/mcp/tools/image_to_text";
+const TIMEOUT_MS = 10000;
+
+async function fetchJSON(url, opts = {}, timeoutMs = TIMEOUT_MS) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, { ...opts, signal: controller.signal });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
+    return text ? JSON.parse(text) : {};
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+class MCPService {
+  constructor() {
+    this.isConnected = false;
+    this.imageKey = 0;
+  }
+
+  async connect() {
+    this.isConnected = true;
+    console.log("[MCP] connected to", BASE_URL);
+  }
+
+  async disconnect() {
+    this.isConnected = false;
+    console.log("[MCP] disconnected");
+  }
+
+  async processImages(imageObjects) {
+    if (!this.isConnected) throw new Error("MCP not connected");
+
+    const body = JSON.stringify({ images: imageObjects });
+
+    const data = await fetchJSON(`${BASE_URL}${OCR_ROUTE}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+
+    return data;
+  }
+
+  async processSingleImage(imageBase64) {
+    this.imageKey += 1;
+    const key = String(this.imageKey);
+    return this.processImages({ [key]: imageBase64 });
+  }
+}
+
+const mcp = new MCPService();
+export default mcp;
+
+// --- quick test ---
+// TODO: delete later
+(async () => {
+  try {
+    await mcp.connect();
+
+    const fakeBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+    const result = await mcp.processSingleImage(fakeBase64);
+    console.log("MCP response:", result);
+
+    await mcp.disconnect();
+  } catch (err) {
+    console.error("MCP test failed:", err);
+  }
+})();


### PR DESCRIPTION
FastAPI is needed to provide an HTTP bridge, since React Native apps can’t communicate with stdio directly.
It lets the mobile client call MCP tools over simple REST endpoints.

`stdio` = standard input/output (the same channels a terminal uses).

MCP protocol is designed to run servers that talk over `stdio` — tools send and receive JSON-RPC messages via plain stdin/stdout streams. That works great when both sides are CLI-based.

But a mobile app can’t open and manage raw stdio streams. That’s why I added FastAPI: to expose the MCP functions over HTTP, which the mobile frontend can call.